### PR TITLE
Update Clock.jsx

### DIFF
--- a/src/assets/Components/Clock.jsx
+++ b/src/assets/Components/Clock.jsx
@@ -10,7 +10,7 @@ export default function Clock() {
         const intervalId = setInterval(() => {
             const date = new Date();
             setTime({
-                minutes: date.getMinutes(),
+                minutes: String(date.getMinutes()).padStart(2, '0'),   // added by Rik to round up the  
                 hours: date.getHours(),
                 seconds: date.getSeconds()
             })


### PR DESCRIPTION
Updated to round up the min value to 2 digit always to tackle issue #2

before
![image](https://github.com/ShrutiKolla/Focus-StudySpace/assets/96734674/63ad85f0-371d-4c78-8cb0-73331ac56ce0)
now
![image](https://github.com/ShrutiKolla/Focus-StudySpace/assets/96734674/e7894f34-dcda-4e3c-a9d4-39df54a68706)

### What I did
I added 
``` js
String(date.getMinutes()).padStart(2, '0')
``` 
This will take minutes value and round it up to 2 digit using padding of '0'

